### PR TITLE
Fix a XSS caused by `userName`

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,8 +1,9 @@
+toastr.options.escapeHtml = true; // to prevent XSS vulnerabilities
+
 if(!Push.Permission.has()) {
   alert("タブが表示されていない時でも友人からの通知を受け取るために通知を許可してください");
   Push.Permission.request();
 }
-
 
 
 const ws_uri = (function(){

--- a/static/main.js
+++ b/static/main.js
@@ -36,7 +36,13 @@ const getSeat = function(x, y) {
   return result;
 }
 
+const escapeHtml = function (rawString) {
+  return $("<span>").text(rawString).html();
+}
 
+const unescapeHtml = function (escapedString) {
+  return $("<span>").html(escapedString).text();
+}
 
 const app = new Vue({
   el: '#app',
@@ -67,7 +73,8 @@ const app = new Vue({
     },
     updateUserInfo: function() {
       if(this.userName.length == 0 || this.userImage.length == 0) return;
-      ws.send(makeUpdateUserInfo(this.userName, this.userImage));
+      const htmlEscapedUserName = escapeHtml(this.userName);
+      ws.send(makeUpdateUserInfo(htmlEscapedUserName, this.userImage));
     },
     clickCanvas: function(e) {
       const x = Math.floor(e.offsetX / 32);
@@ -147,7 +154,7 @@ const app = new Vue({
         const y = s * seatMap[table][seat][0];
         const x = s * seatMap[table][seat][1];
 
-        $this.ctx.fillText(userName, x + s/2, y - s/3);
+        $this.ctx.fillText(unescapeHtml(userName), x + s/2, y - s/3);
         $this.getUserImageWithCache(userImage, function(imageObj) {
           $this.ctx.drawImage(imageObj, x, y, s, s);
         });

--- a/static/main.js
+++ b/static/main.js
@@ -36,13 +36,7 @@ const getSeat = function(x, y) {
   return result;
 }
 
-const escapeHtml = function (rawString) {
-  return $("<span>").text(rawString).html();
-}
 
-const unescapeHtml = function (escapedString) {
-  return $("<span>").html(escapedString).text();
-}
 
 const app = new Vue({
   el: '#app',
@@ -73,8 +67,7 @@ const app = new Vue({
     },
     updateUserInfo: function() {
       if(this.userName.length == 0 || this.userImage.length == 0) return;
-      const htmlEscapedUserName = escapeHtml(this.userName);
-      ws.send(makeUpdateUserInfo(htmlEscapedUserName, this.userImage));
+      ws.send(makeUpdateUserInfo(this.userName, this.userImage));
     },
     clickCanvas: function(e) {
       const x = Math.floor(e.offsetX / 32);
@@ -154,7 +147,7 @@ const app = new Vue({
         const y = s * seatMap[table][seat][0];
         const x = s * seatMap[table][seat][1];
 
-        $this.ctx.fillText(unescapeHtml(userName), x + s/2, y - s/3);
+        $this.ctx.fillText(userName, x + s/2, y - s/3);
         $this.getUserImageWithCache(userImage, function(imageObj) {
           $this.ctx.drawImage(imageObj, x, y, s, s);
         });


### PR DESCRIPTION
ユーザー入力の `userName` をそのまま toastr に引き渡していることで発生しているXSSを修正しました．
例えば `userName` を `<script>alert("hi")</script>` というふうに設定して，第三者にPokeを送ると，Pokeの受け取り側でalertが発火することになり，簡単にサービスを利用できない状況にすることが可能です．
~このpull-requestでは，このアプリケーションがjQueryを使っていたので手っ取り早くjQueryを利用してhtmlのescape及びunescapeを行っていますが，他の方法でも良いとは思います．~
toaster には `toaster.options.escapeHtml` があり，これを `true` にすることで HTML escape させることができるようだったので，その設定を追加しました: https://github.com/CodeSeven/toastr/tree/50092cc604850a16c985520b63df184d3e0b4086#escape-html-characters